### PR TITLE
fix docs font-family bug at safari

### DIFF
--- a/docs/index.ejs
+++ b/docs/index.ejs
@@ -10,7 +10,7 @@
 <link rel="stylesheet" href="https://unpkg.com/react-select/dist/react-select.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body>
+<body class="avenir">
   <div id="root"></div>
   <% if (htmlWebpackPlugin.options.production) { %>
     <script src="https://unpkg.com/react@16.0.0/umd/react.production.min.js"></script>

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -7,14 +7,10 @@ const TabStyle = styled.div`
   display: ${props => props.vertical ? 'block': 'inline-block'};
   ${props => props.vertical ?
     `
-      border-bottom: 1px solid #efefef;
-      border-left: 1px solid #efefef;
-      border-right: 1px solid #efefef;
       background-color: white;
+      color: black;
       padding: 10px 10px;
-      &:first-child {
-        border-top: 1px solid #efefef;        
-      }
+      z-index: 100000;
     `
   : props => props.closable ? 'padding: 10px 10px 10px 15px;' : 'padding: 10px 15px;'
   }

--- a/src/themes/bootstrap/index.js
+++ b/src/themes/bootstrap/index.js
@@ -12,6 +12,22 @@ TabStyle = TabStyle.extend`
   transition: background-color .3s cubic-bezier(.645, .045, .355, 1);
   color: ${props => props.active ? 'black' : '#007bff'};
   border: 1px solid transparent;
+  ${props => props.vertical ?
+    `
+      border-top: 1px solid transparent;
+      border-bottom: 1px solid #efefef;
+      border-left: 1px solid #efefef;
+      border-right: 1px solid #efefef;
+      border-radius: 0;
+      &:first-child {
+        border-top: 1px solid #efefef;        
+      }
+    `
+  : `
+      &:hover {
+        border-color: #ddd #ddd #fff;
+      }
+  `}
   ${props => props.active && props.vertical ?
     `
       background-color: #eee;
@@ -22,9 +38,6 @@ TabStyle = TabStyle.extend`
       border-color: #ddd #ddd #fff;
     `
   : null}
-  &:hover {
-    border-color: #ddd #ddd #fff;
-  }
 `;
 
 export default {


### PR DESCRIPTION
This pr fix #76.

Because the dnd element is injected under body, if the `DragTab` doesn't set `font-family`, the browser will use parent element's font-family.

So the solution is: 
1. set font-family at `body`
2. set font-family at `Tab`.