### PR TITLE
use native map to traverse Panel children

### DIFF
--- a/src/PanelList.js
+++ b/src/PanelList.js
@@ -25,7 +25,7 @@ export default class PanelList extends React.PureComponent<Props> {
       props = {...props, CustomPanelStyle: customStyle.Panel}
     }
 
-    return React.Children.map(children, (child, index) => (
+    return children.map((child, index) => (
       React.cloneElement(child, {
         key: index,
         active: index === activeIndex,


### PR DESCRIPTION
Fix #79 problem.
Because `React.Children` is the new API of `v16.2`, to support old version, use native `map` method to traverse children.
