### PR TITLE
fix touch device cannot dnd bug

### DIFF
--- a/src/DragTabList.js
+++ b/src/DragTabList.js
@@ -19,7 +19,6 @@ export default class DragTabList extends SortMethod {
       <DragTabContainer onSortEnd={this.onSortEnd}
                         axis='x'
                         lockAxis='x'
-                        distance={2}
                         {...props}>
         {children}
       </DragTabContainer>

--- a/src/TabModal.js
+++ b/src/TabModal.js
@@ -25,8 +25,7 @@ class ModalTabListWrapper extends SortMethod {
     return (
       <DragTabContainer onSortEnd={this.onSortEnd}
                         axis='y'
-                        lockAxis='y'
-                        distance={2}>
+                        lockAxis='y'>
         {this.props.children}
       </DragTabContainer>
     );

--- a/test/__snapshots__/DragTabList.test.js.snap
+++ b/test/__snapshots__/DragTabList.test.js.snap
@@ -54,7 +54,7 @@ exports[`DragTabList custom ListStyle style 1`] = `
         "CustomTabList": [Function],
       }
     }
-    distance={2}
+    distance={0}
     getHelperDimensions={[Function]}
     hideSortableGhost={true}
     lockAxis="x"
@@ -206,7 +206,7 @@ exports[`DragTabList render DragTab List 1`] = `
   <sortableList
     axis="x"
     customStyle={Object {}}
-    distance={2}
+    distance={0}
     getHelperDimensions={[Function]}
     hideSortableGhost={true}
     lockAxis="x"


### PR DESCRIPTION
fix #89 bug.

Because at drag container has a `distance` props, this may not be triggered in all mobile devices. Therefore, remove this props to make it workable.