### PR TITLE
update styled-components and jest-styled-compoents

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node devServer.js",
     "build": "npm run build:lib && npm run build:dist",
     "build:lib": "rimraf ./lib && cross-env BABEL_ENV=production babel src -d lib",
-    "build:dist": "rimraf dist && rollup -c --environment ESBUNDLE && rollup -c --environment PRODUCTION",
+    "build:dist":
+      "rimraf dist && rollup -c --environment ESBUNDLE && rollup -c --environment PRODUCTION",
     "lint": "eslint src example test",
     "test": "jest",
     "test:watch": "NODE_ENV=test npm test -- --watch",
@@ -33,13 +34,7 @@
     "tabtab",
     "styled-components"
   ],
-  "files": [
-    "dist",
-    "docs",
-    "flow-typed",
-    "lib",
-    "src"
-  ],
+  "files": ["dist", "docs", "flow-typed", "lib", "src"],
   "author": "ctxhou",
   "license": "MIT",
   "bugs": {
@@ -53,8 +48,7 @@
     "prop-types": "^15.6.0",
     "react-poppop": "^1.4.0",
     "react-sortable-hoc": "^0.6.8",
-    "react-test-renderer": "^16.0.0",
-    "styled-components": "^2.2.3"
+    "react-test-renderer": "^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -96,7 +90,7 @@
     "html-webpack-plugin": "^2.30.1",
     "husky": "^0.14.3",
     "jest": "^20.0.4",
-    "jest-styled-components": "^4.9.0",
+    "jest-styled-components": "^5.0.1",
     "noop3": "^999.999.999",
     "precommit-hook-eslint": "^3.0.0",
     "prettier": "^1.7.4",
@@ -115,32 +109,21 @@
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^2.0.1",
     "rollup-plugin-visualizer": "^0.3.1",
+    "styled-components": "^3.2.6",
     "webpack": "^3.3.0",
     "webpack-bundle-analyzer": "^2.9.0",
     "webpack-dev-middleware": "^1.12.0",
     "webpack-hot-middleware": "^2.18.2"
   },
   "peerDependencies": {
-    "react": ">= 15.0.0 < 17.0.0-0"
+    "react": ">= 15.0.0 < 17.0.0-0",
+    "styled-components": "^3.2.6"
   },
   "jest": {
-    "setupFiles": [
-      "./test/shim",
-      "./test/enzyme-setup"
-    ],
-    "roots": [
-      "<rootDir>/test/"
-    ],
-    "unmockedModulePathPatterns": [
-      "node_modules/react/",
-      "node_modules/enzyme/"
-    ],
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
+    "setupFiles": ["./test/shim", "./test/enzyme-setup"],
+    "roots": ["<rootDir>/test/"],
+    "unmockedModulePathPatterns": ["node_modules/react/", "node_modules/enzyme/"],
+    "snapshotSerializers": ["enzyme-to-json/serializer"]
   },
-  "pre-commit": [
-    "lint",
-    "test"
-  ]
+  "pre-commit": ["lint", "test"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2819,9 +2819,9 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3076,10 +3076,6 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-
-is-function@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -3480,9 +3476,9 @@ jest-snapshot@^20.0.3:
     natural-compare "^1.4.0"
     pretty-format "^20.0.3"
 
-jest-styled-components@^4.9.0:
-  version "4.9.0"
-  resolved "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-4.9.0.tgz#459ccb37d0f5720007c8dba358bfff93c8cf4aed"
+jest-styled-components@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-5.0.1.tgz#386c5a161a0f5e783444d624bfc18c6d228d1277"
   dependencies:
     css "^2.2.1"
 
@@ -4638,6 +4634,10 @@ react-input-autosize@^2.0.1:
     create-react-class "^15.5.2"
     prop-types "^15.5.8"
 
+react-is@^16.3.1:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
+
 react-poppop@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/react-poppop/-/react-poppop-1.4.0.tgz#0c1801924cc1a56acde513cce75233c642e80866"
@@ -5381,23 +5381,28 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-styled-components@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.npmjs.org/styled-components/-/styled-components-2.2.3.tgz#154575c269880c840f903f580287dab155cf684c"
+styled-components@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.2.6.tgz#99e6e75a746bdedd295a17e03dd1493055a1cc3b"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"
-    fbjs "^0.8.9"
-    hoist-non-react-statics "^1.2.0"
-    is-function "^1.0.1"
+    fbjs "^0.8.16"
+    hoist-non-react-statics "^2.5.0"
     is-plain-object "^2.0.1"
     prop-types "^15.5.4"
-    stylis "3.x"
+    react-is "^16.3.1"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
     supports-color "^3.2.3"
 
-stylis@3.x:
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/stylis/-/stylis-3.4.3.tgz#875bd0db3db37bb6de08f89275fc38ee2e32ee75"
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+
+stylis@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hi

Great lib will be very useful after initial tests I came accross a few points for your consideration

This PR bumps the version of Styled Components to version 3, have updated styled-components to version 3 and updated jest-styled-components to version 5. Styled Components version 3 is backwards compatible with versions 1 and 2 [LINK](https://medium.com/styled-components/v3-1-0-such-perf-wow-many-streams-c45c434dbd03) so should be a seamless upgrade.

When styled component is already is use it can currently encounter the multiple instances of styled-components error [LINK](https://www.styled-components.com/docs/faqs#why-am-i-getting-a-warning-about-several-instances-of-module-on-the-page) this PR has moved styled-components to devDependencies and added it as a peerDependencies as  recommened by styled-components author [LINK](https://www.styled-components.com/docs/faqs#i-am-a-library-author-should-i-bundle-styledcomponents-with-my-library)

Many thanks 

Iain





