### PR TITLE
issue 116/146: bump delay to above 100 ms

### DIFF
--- a/src/DragTabList.js
+++ b/src/DragTabList.js
@@ -21,7 +21,7 @@ export default class DragTabList extends SortMethod {
                         lockAxis='x'
                         // if no pressDelay, close button cannot be triggered,
                         // because it would always treat click as dnd action
-                        pressDelay={100}
+                        pressDelay={110}
                         {...props}>
         {children}
       </DragTabContainer>


### PR DESCRIPTION
As seen in the discussion of Issue 116:https://github.com/ctxhou/react-tabtab/issues/116 and later issue 147: https://github.com/ctxhou/react-tabtab/issues/147, the current 100 ms delay on close button isn't registering for people. 110 ms solves this issue without being noticeably slower to register movement like the suggested 200ms.

Adding this change to the repo prevents the need for people to copy react-tabtab files locally